### PR TITLE
explicitly requesting `dist: trusty`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ which-steps: &which-steps
 
 trusty-steps: &trusty-steps
   os: linux
+  dist: trusty
   <<: *which-steps
 
 xenial-steps: &xenial-steps


### PR DESCRIPTION
This will be helpful once the default starts changing from trusty to xenial :)